### PR TITLE
Fix --base flag handling for files

### DIFF
--- a/__tests__/helpers/template.ts
+++ b/__tests__/helpers/template.ts
@@ -1,18 +1,31 @@
+import { AddOptions } from '@application/commands/create';
+
 export const mockCreateTemplateProps = (
     props?: Partial<{
         templateName: string;
         source: string[];
-        options: Partial<{ base: boolean; force: boolean; recursive: boolean; exclude: string[] }>;
+        options: Partial<AddOptions>;
     }>
 ) => {
     return {
         templateName: props?.templateName ?? 'template-name',
         source: props?.source ?? ['./source'],
         options: {
-            base: props?.options?.base ?? false,
+            preserveLastDir: props?.options?.preserveLastDir ?? false,
             force: props?.options?.force ?? false,
             recursive: props?.options?.recursive ?? false,
             exclude: props?.options?.exclude ?? [],
         },
     };
+};
+
+export const mockAddOptions = (options?: Partial<AddOptions>) => {
+    const defaultOptions = {
+        preserveLastDir: false,
+        force: false,
+        recursive: false,
+        exclude: [],
+    };
+
+    return Object.assign(defaultOptions, options);
 };

--- a/__tests__/unit/core/path-resolution/destination-resolver.test.ts
+++ b/__tests__/unit/core/path-resolution/destination-resolver.test.ts
@@ -22,20 +22,20 @@ describe('DestinationResolver', () => {
         it('Should resolve target path correctly with one source', () => {
             vi.spyOn(process, 'cwd').mockImplementation(() => '/root');
             const source = ['./project/**'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPath = '/root/project/dir';
 
             const result = new DestinationResolver(source, destination).resolve({
-                basePath,
+                destinationSubpath,
                 targetPath,
             });
 
-            expect(result).toBe(join(destination, basePath, 'dir'));
+            expect(result).toBe(join(destination, destinationSubpath, 'dir'));
         });
 
         it('Should resolve many target paths correctly with one source', () => {
             const source = ['./project/**'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPaths = [
                 '/root/project/dir',
                 '/root/project/nested/dir',
@@ -45,20 +45,20 @@ describe('DestinationResolver', () => {
             const resolver = new DestinationResolver(source, destination);
 
             const result = targetPaths.map(targetPath => {
-                return resolver.resolve({ basePath, targetPath });
+                return resolver.resolve({ destinationSubpath, targetPath });
             });
 
             expect(result).toEqual([
-                join(destination, basePath, 'dir'),
-                join(destination, basePath, 'nested/dir'),
-                join(destination, basePath, 'very/nested/dir'),
-                join(destination, basePath, 'another/dir/that/is/very/nested'),
+                join(destination, destinationSubpath, 'dir'),
+                join(destination, destinationSubpath, 'nested/dir'),
+                join(destination, destinationSubpath, 'very/nested/dir'),
+                join(destination, destinationSubpath, 'another/dir/that/is/very/nested'),
             ]);
         });
 
         it('Should resolve many target paths correctly with many source paths', () => {
             const source = ['./project/**', './documents/*', './some/stuff/**/*'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPaths = [
                 '/root/project/dir',
                 '/root/project/another/dir/that/is/very/nested',
@@ -68,31 +68,35 @@ describe('DestinationResolver', () => {
             const resolver = new DestinationResolver(source, destination);
 
             const result = targetPaths.map(targetPath => {
-                return resolver.resolve({ basePath, targetPath });
+                return resolver.resolve({ destinationSubpath, targetPath });
             });
 
             expect(result).toEqual([
-                join(destination, basePath, 'dir'),
-                join(destination, basePath, 'another/dir/that/is/very/nested'),
-                join(destination, basePath, 'very/nested/dir'),
-                join(destination, basePath, 'file.txt'),
+                join(destination, destinationSubpath, 'dir'),
+                join(destination, destinationSubpath, 'another/dir/that/is/very/nested'),
+                join(destination, destinationSubpath, 'very/nested/dir'),
+                join(destination, destinationSubpath, 'file.txt'),
             ]);
         });
 
         it('Should resolve target path correctly with includeSourceBase flag set to true', () => {
             const source = ['./project/**'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPath = '/root/project/dir';
             const resolver = new DestinationResolver(source, destination);
 
-            const result = resolver.resolve({ basePath, targetPath, includeSourceBase: true });
+            const result = resolver.resolve({
+                destinationSubpath,
+                targetPath,
+                preserveLastSourceDir: true,
+            });
 
-            expect(result).toBe(join(destination, basePath, 'project', 'dir'));
+            expect(result).toBe(join(destination, destinationSubpath, 'project', 'dir'));
         });
 
         it('Should resolve many target paths correctly with many source paths and with includeSourceBase flag set to true', () => {
             const source = ['./project/**', './documents/*', './some/stuff/**/*'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPaths = [
                 '/root/project/dir',
                 '/root/project/another/dir/that/is/very/nested',
@@ -102,20 +106,24 @@ describe('DestinationResolver', () => {
             const resolver = new DestinationResolver(source, destination);
 
             const result = targetPaths.map(targetPath => {
-                return resolver.resolve({ basePath, targetPath, includeSourceBase: true });
+                return resolver.resolve({
+                    destinationSubpath,
+                    targetPath,
+                    preserveLastSourceDir: true,
+                });
             });
 
             expect(result).toEqual([
-                join(destination, basePath, 'project/dir'),
-                join(destination, basePath, 'project/another/dir/that/is/very/nested'),
-                join(destination, basePath, 'stuff/very/nested/dir'),
-                join(destination, basePath, 'documents/file.txt'),
+                join(destination, destinationSubpath, 'project/dir'),
+                join(destination, destinationSubpath, 'project/another/dir/that/is/very/nested'),
+                join(destination, destinationSubpath, 'stuff/very/nested/dir'),
+                join(destination, destinationSubpath, 'documents/file.txt'),
             ]);
         });
 
         it('Should resolve many target paths correctly with colliding source paths and includeSourceBase flag set to true', () => {
             const source = ['./projects/**', './projects/utils/*', './projects/utils/helpers/**'];
-            const basePath = 'my-template';
+            const destinationSubpath = 'my-template';
             const targetPaths = [
                 '/root/projects/utils/helper.ts',
                 '/root/projects/utils/helpers/array.ts',
@@ -125,14 +133,18 @@ describe('DestinationResolver', () => {
             const resolver = new DestinationResolver(source, destination);
 
             const result = targetPaths.map(targetPath => {
-                return resolver.resolve({ basePath, targetPath, includeSourceBase: true });
+                return resolver.resolve({
+                    destinationSubpath,
+                    targetPath,
+                    preserveLastSourceDir: true,
+                });
             });
 
             expect(result).toEqual([
-                join(destination, basePath, 'utils', 'helper.ts'),
-                join(destination, basePath, 'helpers', 'array.ts'),
-                join(destination, basePath, 'projects', 'app/main.ts'),
-                join(destination, basePath, 'projects', 'package.json'),
+                join(destination, destinationSubpath, 'utils', 'helper.ts'),
+                join(destination, destinationSubpath, 'helpers', 'array.ts'),
+                join(destination, destinationSubpath, 'projects', 'app/main.ts'),
+                join(destination, destinationSubpath, 'projects', 'package.json'),
             ]);
         });
     });

--- a/__tests__/unit/core/template/create-template-props-preparer.test.ts
+++ b/__tests__/unit/core/template/create-template-props-preparer.test.ts
@@ -28,6 +28,20 @@ describe('CreateTemplatePropsPreparer', () => {
             expect(result.source).toEqual(['dir1/**', 'dir2/**', 'dir3/*', 'file.txt', '.file']);
         });
 
+        it('should convert simple dir paths to glob patterns when recursive is false', () => {
+            vi.spyOn(fileSystem, 'isDirSync').mockImplementation((path: PathLike) => {
+                return ['dir1/', 'dir2'].some(el => el === path);
+            });
+            const props = mockCreateTemplateProps({
+                source: ['dir1/', 'dir2', 'dir3/*', 'file.txt', '.file'],
+                options: { recursive: false },
+            });
+
+            const result = CreateTemplatePropsPreparer.prepare(props);
+
+            expect(result.source).toEqual(['dir1/*', 'dir2/*', 'dir3/*', 'file.txt', '.file']);
+        });
+
         it('should convert simple exclude paths to recursive glob patterns', () => {
             const props = mockCreateTemplateProps({
                 options: {

--- a/src/application/commands/create/create-command.ts
+++ b/src/application/commands/create/create-command.ts
@@ -6,10 +6,14 @@ import CreateTemplateOperation from '@core/template/operations/create-template-o
 export default function buildCreateCommand() {
     return new Command('create')
         .alias('new')
-        .argument('<template-name>', 'unique template name')
-        .argument('<source...>', 'source to save as template')
+        .argument('<template-name>', 'unique template identifier')
+        .argument('<source...>', 'sources to save as template')
         .option('-f, --force', 'ignore warnings and errors', false)
-        .option('-b, --base', 'include source directory to template', false)
+        .option(
+            '-p, --preserve-last-dir',
+            'preserve only the final directory name from path patterns (ignored for file sources)',
+            false
+        )
         .option('-r, --recursive', 'copy directories recursively (works like glob `dir/**`)', false)
         .option(
             '-x, --exclude <patterns>',

--- a/src/application/commands/create/types.ts
+++ b/src/application/commands/create/types.ts
@@ -1,9 +1,9 @@
 export type AddOptions = {
     /**
-     * Include source directory to template
+     * Include last directory from source path to template
      * @default false
      */
-    base: boolean;
+    preserveLastDir: boolean;
     /**
      * Ignore warnings and errors
      * @default false

--- a/src/core/path-resolution/services/destination-resolver.ts
+++ b/src/core/path-resolution/services/destination-resolver.ts
@@ -18,7 +18,7 @@ export default class DestinationResolver {
      * Determines which source pattern matches the target path, then constructs
      * destination path by combining:
      * 1. destinationRoot
-     * 2. basePath
+     * 2. destinationSubpath
      * 3. Relative path from pattern's parent directory to target file
      *
      * Patterns are checked in descending order of specificity (longest parentPath first).
@@ -28,32 +28,36 @@ export default class DestinationResolver {
      * // - source: ['/projects/*.ts', '/projects/utils/**']
      * // - destinationRoot: '/var/storage'
      *
-     * // Without source base:
+     * // Without source final dir:
      * resolve({
      *   targetPath: '/projects/utils/helpers.ts',
-     *   basePath: 'backup',
-     *   includeSourceBase: false
+     *   destinationSubpath: 'backup',
+     *   preserveLastSourceDir: false
      * })
      * // -> '/var/storage/backup/helpers.ts'
      *
-     * // With source base:
+     * // With source final dir:
      * resolve({
      *   targetPath: '/projects/utils/helpers.ts',
-     *   basePath: 'backup',
-     *   includeSourceBase: true,
+     *   destinationSubpath: 'backup',
+     *   preserveLastSourceDir: true,
      * })
      * // -> '/var/storage/backup/utils/helpers.ts'
      */
-    resolve({ targetPath, basePath = '.', includeSourceBase = false }: ResolveOptions): string {
+    resolve({
+        targetPath,
+        destinationSubpath = '',
+        preserveLastSourceDir = false,
+    }: ResolveOptions): string {
         for (const { parentPath, originalGlob } of this.resolvedSourcePatterns) {
             if (!targetPath.startsWith(parentPath)) continue;
 
             if (matchGlob(targetPath, originalGlob)) {
-                const finalBasePath = includeSourceBase
-                    ? join(basePath, parse(parentPath).base)
-                    : basePath;
+                const finalSourceDir = preserveLastSourceDir
+                    ? join(destinationSubpath, parse(parentPath).base)
+                    : destinationSubpath;
 
-                return this.getDestinationPath(finalBasePath, parentPath, targetPath);
+                return this.getDestinationPath(finalSourceDir, parentPath, targetPath);
             }
         }
 
@@ -87,4 +91,3 @@ export default class DestinationResolver {
         );
     }
 }
-

--- a/src/core/path-resolution/services/types.ts
+++ b/src/core/path-resolution/services/types.ts
@@ -10,6 +10,6 @@ export type ResolvedSourcePattern = {
 
 export type ResolveOptions = {
     targetPath: string;
-    basePath?: string;
-    includeSourceBase?: boolean;
+    destinationSubpath?: string;
+    preserveLastSourceDir?: boolean;
 };

--- a/src/core/path-resolution/services/types.ts
+++ b/src/core/path-resolution/services/types.ts
@@ -8,8 +8,7 @@ export type ResolvedSourcePattern = {
     originalGlob: string;
 };
 
-export type ResolveOptions = {
-    targetPath: string;
+export type ResolveParams = {
     destinationSubpath?: string;
     preserveLastSourceDir?: boolean;
 };

--- a/src/core/template/entities/template-entry-factory.ts
+++ b/src/core/template/entities/template-entry-factory.ts
@@ -32,8 +32,8 @@ export default class TemplateEntryFactory implements Factory<TemplateEntry, Temp
         entries: FileSystemEntry[];
         source: string[];
         destination: string;
-        templateName: string;
-        options?: Pick<AddOptions, 'base'>;
+        templateName?: string;
+        options?: Pick<AddOptions, 'preserveLastDir'>;
     }): TemplateEntry[] {
         const destinationResolver = this.destResolverFactory.create({ source, destination });
         const templateEntries: TemplateEntry[] = [];
@@ -43,8 +43,8 @@ export default class TemplateEntryFactory implements Factory<TemplateEntry, Temp
 
             const entyDest = destinationResolver.resolve({
                 targetPath: entry.path,
-                basePath: templateName,
-                includeSourceBase: options?.base ?? false,
+                destinationSubpath: templateName ?? '',
+                preserveLastSourceDir: entry.isFile() ? false : (options?.preserveLastDir ?? false),
             });
 
             templateEntries.push(this.create({ entry, destination: entyDest }));

--- a/src/core/template/entities/template-entry-factory.ts
+++ b/src/core/template/entities/template-entry-factory.ts
@@ -41,10 +41,9 @@ export default class TemplateEntryFactory implements Factory<TemplateEntry, Temp
         for (const entry of entries) {
             if (!entry.name) continue;
 
-            const entyDest = destinationResolver.resolve({
-                targetPath: entry.path,
+            const entyDest = destinationResolver.resolve(entry.path, {
                 destinationSubpath: templateName ?? '',
-                preserveLastSourceDir: entry.isFile() ? false : (options?.preserveLastDir ?? false),
+                preserveLastSourceDir: options?.preserveLastDir ?? false,
             });
 
             templateEntries.push(this.create({ entry, destination: entyDest }));

--- a/src/core/template/schemas/create-template-schema.ts
+++ b/src/core/template/schemas/create-template-schema.ts
@@ -32,8 +32,8 @@ export default class CreateTemplateSchema extends TemplateSchema {
         return this.parse(TemplateSchema.BOOLEAN_SCHEMA, value, 'recursive');
     }
 
-    base(value: unknown = false): boolean {
-        return this.parse(TemplateSchema.BOOLEAN_SCHEMA, value, 'base');
+    preserveLastDir(value: unknown = false): boolean {
+        return this.parse(TemplateSchema.BOOLEAN_SCHEMA, value, 'preserveLastDir');
     }
 
     props(value: unknown = {}): CreateTemplateProps {
@@ -43,7 +43,7 @@ export default class CreateTemplateSchema extends TemplateSchema {
             templateName: this.templateName(value.templateName),
             source: this.source(value.source),
             options: {
-                base: this.base(value.options.base),
+                preserveLastDir: this.preserveLastDir(value.options.preserveLastDir),
                 exclude: this.exclude(value.options.exclude),
                 force: this.force(value.options.force),
                 recursive: this.recursive(value.options.recursive),

--- a/src/core/template/services/template-service.ts
+++ b/src/core/template/services/template-service.ts
@@ -62,7 +62,6 @@ export default class TemplateService {
 
         const templateEntries = this.templateEntryFactory.createMany({
             entries: fileSystemEntries,
-            templateName: '',
             source: [templatePath],
             destination,
         });

--- a/src/shared/utils/glob.ts
+++ b/src/shared/utils/glob.ts
@@ -3,3 +3,8 @@ import globParent from 'glob-parent';
 export function getParentPathFromGlobString(path: string): string {
     return globParent(path);
 }
+
+export function isGlobPattern(path: string): boolean {
+    const globPatternRegex = /[\!\?\*\[\]\{\},]/;
+    return globPatternRegex.test(path);
+}


### PR DESCRIPTION
This PR resolves the issue where the `--base` flag incorrectly created unwanted parent directories for explicit file paths.

## Changes

- Renamed `--base` flag to `--preserve-last-dir` for better clarity
- Fixed directory preservation logic to only apply to glob patterns, not explicit files
- Updated variable names and improved path resolution consistency
- Enhanced related components with clearer naming conventions

## Result

**Before:**
```sh
tbox create test ./parent-dir/README.md --preserve-last-dir

# test/
# └── parent-dir/  # Unwanted directory
#     └── README.md
```

After:

```sh
tbox create test ./parent-dir/README.md --preserve-last-dir  
# test/
#  └── README.md  # File without extra directory
```
The flag now correctly preserves directory structure only for directory/glob sources while handling explicit file paths as expected.

Closes #10